### PR TITLE
1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'dev.architectury.loom' version '1.11-SNAPSHOT' apply false
+    id 'dev.architectury.loom' version '1.13-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }

--- a/common/src/main/java/cc/barnab/smoothmaps/client/MapInstanceDirty.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/client/MapInstanceDirty.java
@@ -1,6 +1,6 @@
 package cc.barnab.smoothmaps.client;
 
-import net.minecraft.world.entity.decoration.Painting;
+import net.minecraft.world.entity.decoration.painting.Painting;
 
 public interface MapInstanceDirty {
     default void setDirty(int x, int y, int w, int h) {

--- a/common/src/main/java/cc/barnab/smoothmaps/client/PaintingStateAccessor.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/client/PaintingStateAccessor.java
@@ -1,6 +1,6 @@
 package cc.barnab.smoothmaps.client;
 
-import net.minecraft.world.entity.decoration.Painting;
+import net.minecraft.world.entity.decoration.painting.Painting;
 
 public interface PaintingStateAccessor {
     default Painting getPainting() {

--- a/common/src/main/java/cc/barnab/smoothmaps/client/RenderRelightCounter.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/client/RenderRelightCounter.java
@@ -4,6 +4,9 @@ public interface RenderRelightCounter {
     default int getNumRendered() {
         return 0;
     }
+    default int getNumSmoothLit() {
+        return 0;
+    }
     default int getNumRelit() {
         return 0;
     }

--- a/common/src/main/java/cc/barnab/smoothmaps/client/SmoothMapsDebugEntry.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/client/SmoothMapsDebugEntry.java
@@ -6,7 +6,7 @@ import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
 import net.minecraft.client.gui.components.debug.DebugScreenEntry;
 import net.minecraft.client.renderer.MapRenderer;
 import net.minecraft.client.renderer.entity.PaintingRenderer;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.Unique;
 
 public class SmoothMapsDebugEntry implements DebugScreenEntry {
     @Unique
-    public static final ResourceLocation GROUP = ResourceLocation.withDefaultNamespace("smoothmaps_stats");
+    public static final Identifier GROUP = Identifier.withDefaultNamespace("smoothmaps_stats");
 
     @Unique
     private static final String VERSION_STR = "SmoothMaps v%s".formatted(SmoothMaps.MOD_VERSION);
@@ -26,11 +26,11 @@ public class SmoothMapsDebugEntry implements DebugScreenEntry {
 
         if (Minecraft.useAmbientOcclusion()) {
             MapRenderer mapRenderer = Minecraft.getInstance().getMapRenderer();
-            debugScreenDisplayer.addToGroup(GROUP, "Framed maps: " + mapRenderer.getNumRendered() + " (" + mapRenderer.getNumRelit() + " relit)");
+            debugScreenDisplayer.addToGroup(GROUP, "Framed maps: " + mapRenderer.getNumSmoothLit() + "/" + mapRenderer.getNumRendered() + " (" + mapRenderer.getNumRelit() + " relit)");
 
             PaintingRenderer paintingRenderer = (PaintingRenderer) Minecraft.getInstance().getEntityRenderDispatcher().renderers.get(EntityType.PAINTING);
             if (paintingRenderer != null) {
-                debugScreenDisplayer.addToGroup(GROUP, "Paintings: " + paintingRenderer.getNumRendered() + " (" + paintingRenderer.getNumRelit() + " relit)");
+                debugScreenDisplayer.addToGroup(GROUP, "Paintings: " + paintingRenderer.getNumSmoothLit() + "/" + paintingRenderer.getNumRendered() + " (" + paintingRenderer.getNumRelit() + " relit)");
             }
         } else {
             debugScreenDisplayer.addToGroup(GROUP, "Smooth lighting disabled.");

--- a/common/src/main/java/cc/barnab/smoothmaps/mixin/client/DebugScreenEntriesMixin.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/mixin/client/DebugScreenEntriesMixin.java
@@ -3,7 +3,7 @@ package cc.barnab.smoothmaps.mixin.client;
 import cc.barnab.smoothmaps.client.SmoothMapsDebugEntry;
 import net.minecraft.client.gui.components.debug.DebugScreenEntries;
 import net.minecraft.client.gui.components.debug.DebugScreenEntry;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -12,11 +12,11 @@ import org.spongepowered.asm.mixin.Unique;
 public abstract class DebugScreenEntriesMixin {
 
     @Shadow
-    private static ResourceLocation register(ResourceLocation arg, DebugScreenEntry arg2) {
+    private static Identifier register(Identifier arg, DebugScreenEntry arg2) {
         return null;
     }
 
     @Unique
-    private static final ResourceLocation SMOOTHMAPS_STATS =
-            register(ResourceLocation.fromNamespaceAndPath("smoothmaps", "stats"), new SmoothMapsDebugEntry());
+    private static final Identifier SMOOTHMAPS_STATS =
+            register(Identifier.fromNamespaceAndPath("smoothmaps", "stats"), new SmoothMapsDebugEntry());
 }

--- a/common/src/main/java/cc/barnab/smoothmaps/mixin/client/GameRendererMixin.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/mixin/client/GameRendererMixin.java
@@ -1,13 +1,10 @@
 package cc.barnab.smoothmaps.mixin.client;
 
 import cc.barnab.smoothmaps.client.GameRenderTimeGetter;
-import cc.barnab.smoothmaps.mixin.client.map.MapRendererMixin;
-import cc.barnab.smoothmaps.mixin.client.painting.PaintingRendererMixin;
-import net.minecraft.Util;
+import net.minecraft.util.Util;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.client.renderer.MapRenderer;
 import net.minecraft.client.renderer.entity.PaintingRenderer;
 import net.minecraft.world.entity.EntityType;
 import org.spongepowered.asm.mixin.Mixin;

--- a/common/src/main/java/cc/barnab/smoothmaps/mixin/client/map/ItemFrameRendererMixin.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/mixin/client/map/ItemFrameRendererMixin.java
@@ -1,23 +1,35 @@
 package cc.barnab.smoothmaps.mixin.client.map;
 
-import cc.barnab.smoothmaps.client.MapRenderStateAccessor;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.MapRenderer;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.entity.EntityRenderer;
-import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemFrameRenderer;
 import net.minecraft.client.renderer.entity.state.ItemFrameRenderState;
+import net.minecraft.client.renderer.item.ItemModelResolver;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.state.CameraRenderState;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.saveddata.maps.MapId;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemFrameRenderer.class)
-public class ItemFrameRendererMixin {
+public abstract class ItemFrameRendererMixin<T extends ItemFrame> {
+
+    @Shadow
+    @Final
+    private MapRenderer mapRenderer;
+
     @Inject(
             method = "submit(Lnet/minecraft/client/renderer/entity/state/ItemFrameRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
             at = @At("HEAD")
@@ -35,7 +47,25 @@ public class ItemFrameRendererMixin {
     }
 
     @Inject(method = "extractRenderState(Lnet/minecraft/world/entity/decoration/ItemFrame;Lnet/minecraft/client/renderer/entity/state/ItemFrameRenderState;F)V", at = @At("TAIL"))
-    private void extractRenderState(ItemFrame itemFrame, ItemFrameRenderState itemFrameRenderState, float f, CallbackInfo ci) {
+    private void extractRenderState(T itemFrame, ItemFrameRenderState itemFrameRenderState, float f, CallbackInfo ci) {
         itemFrameRenderState.setItemFrame(itemFrame);
+    }
+
+    @WrapWithCondition(method = "extractRenderState(Lnet/minecraft/world/entity/decoration/ItemFrame;Lnet/minecraft/client/renderer/entity/state/ItemFrameRenderState;F)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/item/ItemModelResolver;updateForNonLiving(Lnet/minecraft/client/renderer/item/ItemStackRenderState;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemDisplayContext;Lnet/minecraft/world/entity/Entity;)V"))
+    private boolean updateItemModelOnlyWhenNeeded(ItemModelResolver instance, ItemStackRenderState arg, ItemStack itemStack, ItemDisplayContext arg3, Entity entity) {
+        // Skip itemModelResolver.updateForNonLiving if we have a map we can render
+        // Should improve performance for framed maps.
+        // Extra checks don't have much impact, don't worry about deduplicating.
+
+        ItemFrame itemFrame = (ItemFrame)entity;
+        if (!itemStack.isEmpty()) {
+            MapId mapId = itemFrame.getFramedMapId(itemStack);
+            if (mapId != null) {
+                MapItemSavedData mapItemSavedData = itemFrame.level().getMapData(mapId);
+                return mapItemSavedData == null;
+            }
+        }
+
+        return true;
     }
 }

--- a/common/src/main/java/cc/barnab/smoothmaps/mixin/client/painting/PaintingMixin.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/mixin/client/painting/PaintingMixin.java
@@ -1,10 +1,9 @@
 package cc.barnab.smoothmaps.mixin.client.painting;
 
 import cc.barnab.smoothmaps.client.PaintingLightAccessor;
-import net.minecraft.client.renderer.entity.state.PaintingRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.entity.decoration.Painting;
+import net.minecraft.world.entity.decoration.painting.Painting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 

--- a/common/src/main/java/cc/barnab/smoothmaps/mixin/client/painting/PaintingRenderStateMixin.java
+++ b/common/src/main/java/cc/barnab/smoothmaps/mixin/client/painting/PaintingRenderStateMixin.java
@@ -2,7 +2,7 @@ package cc.barnab.smoothmaps.mixin.client.painting;
 
 import cc.barnab.smoothmaps.client.PaintingStateAccessor;
 import net.minecraft.client.renderer.entity.state.PaintingRenderState;
-import net.minecraft.world.entity.decoration.Painting;
+import net.minecraft.world.entity.decoration.painting.Painting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 

--- a/common/src/main/resources/smoothmaps.accesswidener
+++ b/common/src/main/resources/smoothmaps.accesswidener
@@ -11,7 +11,7 @@ accessible field net/minecraft/client/renderer/GameRenderer oldFovModifier F
 
 accessible field net/minecraft/client/renderer/entity/EntityRenderDispatcher renderers Ljava/util/Map;
 
-accessible method net/minecraft/client/gui/components/debug/DebugScreenEntries register (Ljava/lang/String;Lnet/minecraft/client/gui/components/debug/DebugScreenEntry;)Lnet/minecraft/resources/ResourceLocation;
+accessible method net/minecraft/client/gui/components/debug/DebugScreenEntries register (Ljava/lang/String;Lnet/minecraft/client/gui/components/debug/DebugScreenEntry;)Lnet/minecraft/resources/Identifier;
 
 accessible class net/minecraft/client/resources/MapTextureManager$MapInstance
 accessible field net/minecraft/client/renderer/texture/DynamicTexture pixels Lcom/mojang/blaze3d/platform/NativeImage;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Mod properties
-mod_version=1.5.0
+mod_version=1.5.1
 maven_group=cc.barnab
 archives_name=smoothmaps
 enabled_platforms=fabric,neoforge
 # Minecraft properties
-min_minecraft_version=1.21.9
-max_minecraft_version=1.21.10
-minecraft_version=1.21.10
+min_minecraft_version=1.21.11
+max_minecraft_version=1.21.11
+minecraft_version=1.21.11
 # Dependencies
-fabric_loader_version=0.17.0
-neoforge_version=21.10.49-beta
+fabric_loader_version=0.18.4
+neoforge_version=21.11.19-beta


### PR DESCRIPTION
update to support 1.21.11

includes some other changes:
- max smooth light distance for maps removed
- painting lighting updates when variant is changed
- held map no longer counts in f3 menu counter
- f3 menu counter shows number smoothly lit
- framed item model update skipped when rendering map